### PR TITLE
refactor!: combine print inside the main stylesheet

### DIFF
--- a/app/assets/stylesheets/adminterface/_base.scss
+++ b/app/assets/stylesheets/adminterface/_base.scss
@@ -7,5 +7,14 @@
 @import "./placeholders/all";
 @import "./helpers/all";
 @import "./vendors/all";
-@import "./layouts/all";
 @import "./components/all";
+
+/* stylelint-disable no-invalid-position-at-import-rule */
+@media screen {
+  @import "./layouts/all";
+}
+
+@media print {
+  @import "./print";
+}
+/* stylelint-enable no-invalid-position-at-import-rule */

--- a/app/assets/stylesheets/adminterface/_print.scss
+++ b/app/assets/stylesheets/adminterface/_print.scss
@@ -1,14 +1,3 @@
-@import "./vendors/bootstrap/variables";
-@import "bootstrap/scss/bootstrap";
-@import "bootstrap-icons/font/bootstrap-icons";
-@import "flatpickr/dist/flatpickr";
-@import "tom-select/dist/css/tom-select.bootstrap5";
-@import "./mixins/all";
-@import "./placeholders/all";
-@import "./helpers/all";
-@import "./vendors/all";
-@import "./components/all";
-
 // Header
 .navbar-toggler {
   display: none;
@@ -23,7 +12,7 @@
 
 // Main
 #wrapper {
-  padding: $spacer 0;
+  padding: 1rem 0;
 }
 
 // Table

--- a/app/assets/stylesheets/adminterface/layouts/_logged_in.scss
+++ b/app/assets/stylesheets/adminterface/layouts/_logged_in.scss
@@ -1,5 +1,5 @@
 body.logged_in {
-  @extend %layout-scrollable;
+  @include layout-scrollable;
 
   overflow-x: hidden;
 

--- a/app/assets/stylesheets/adminterface/layouts/types/_navigation_top.scss
+++ b/app/assets/stylesheets/adminterface/layouts/types/_navigation_top.scss
@@ -5,7 +5,7 @@ $_title-bar: map-get($layout-navigation-top, 'title_bar');
 $_title-bar-height: map-get($_title-bar, 'height');
 $_title-bar-zindex: map-get($_title-bar, "z-index");
 
-%layout-navigation-top {
+body.layout-navigation-top {
   grid-template-areas:
     "header"
     "title_bar"
@@ -31,5 +31,3 @@ $_title-bar-zindex: map-get($_title-bar, "z-index");
     #filters.aside { top: calc(#{$_header-height} + #{$_title-bar-height}); }
   }
 }
-
-body.layout-navigation-top { @extend %layout-navigation-top; }

--- a/app/assets/stylesheets/adminterface/mixins/_all.scss
+++ b/app/assets/stylesheets/adminterface/mixins/_all.scss
@@ -1,2 +1,3 @@
-@import "./variables";
+@import "./layouts";
 @import "./utilities";
+@import "./variables";

--- a/app/assets/stylesheets/adminterface/mixins/_layouts.scss
+++ b/app/assets/stylesheets/adminterface/mixins/_layouts.scss
@@ -1,4 +1,4 @@
-%layout-scrollable {
+@mixin layout-scrollable {
   width: 100%;
   height: 100%;
 

--- a/app/assets/stylesheets/adminterface/placeholders/_all.scss
+++ b/app/assets/stylesheets/adminterface/placeholders/_all.scss
@@ -1,4 +1,3 @@
-@import './layouts';
 @import './aa_icon';
 @import './background';
 @import './typography';

--- a/lib/generators/adminterface/webpacker/templates/print.scss
+++ b/lib/generators/adminterface/webpacker/templates/print.scss
@@ -1,1 +1,3 @@
-@import "~@cmdbrew/adminterface/src/scss/print";
+/* Active Admin Print Stylesheet */
+// Keeping this file for activeadmin <= 2.9.0 backward compatibility. The latest ActiveAdmin has combined print.scss into the main file.
+// https://github.com/activeadmin/activeadmin/pull/6922/commits/14b64cdf946449091a467ea22adbafd88782b614


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->
<!-- Please ensure your commits follows the [Conventional Commit Messages](https://github.com/CMDBrew/adminterface/blob/main/CODE_OF_CONDUCT.md#conventional-commit-messages) format. -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): ActiveAdmin compatibility update

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue Number(s): N/A

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
- Combine `print.scss` into the main stylesheet
- Update `print.scss` template to show warnings

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
BREAKING CHANGE: The latest ActiveAdmin has combined print.scss into the main file— https://github.com/activeadmin/activeadmin/pull/6922/commits/14b64cdf946449091a467ea22adbafd88782b614
