### PR TITLE
fix: add temp fix for active_admin_comments author validation

### DIFF
--- a/lib/generators/adminterface/comments/templates/active_admin_comment_action_text.rb
+++ b/lib/generators/adminterface/comments/templates/active_admin_comment_action_text.rb
@@ -3,6 +3,11 @@ module Adminterface
     extend ActiveSupport::Concern
 
     included do
+      # Fix author validation issue— https://github.com/activeadmin/activeadmin/issues/5258
+      _validate_callbacks.each do |callback|
+        callback.raw_filter.attributes.delete :author
+      end
+
       has_rich_text :body
     end
   end

--- a/test/dummy/config/initializers/active_admin_comment_action_text.rb
+++ b/test/dummy/config/initializers/active_admin_comment_action_text.rb
@@ -3,6 +3,11 @@ module Adminterface
     extend ActiveSupport::Concern
 
     included do
+      # Fix author validation issue— https://github.com/activeadmin/activeadmin/issues/5258
+      _validate_callbacks.each do |callback|
+        callback.raw_filter.attributes.delete :author
+      end
+
       has_rich_text :body
     end
   end


### PR DESCRIPTION
RELATED TO: https://github.com/activeadmin/activeadmin/issues/5258

<!-- Please provide a general summary of your changes in the title above -->
<!-- Please ensure your commits follows the [Conventional Commit Messages](https://github.com/CMDBrew/adminterface/blob/main/CODE_OF_CONDUCT.md#conventional-commit-messages) format. -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue Number(s): https://github.com/activeadmin/activeadmin/issues/5258

The `author` field is required by default. If the admin panel does not require sign-in then you cannot add comments

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
- Add temporary fix in the generated `active_admin_comment_action_text.rb` template to bypass this validation

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
This temporary fix can be removed once it is addressed on the ActiveAdmin repo.
