### PR TITLE
fix: confirm dialog configs should inherit from backend configs

### DIFF
--- a/app/javascript/adminterface/lib/confirm_dialog.js
+++ b/app/javascript/adminterface/lib/confirm_dialog.js
@@ -1,7 +1,7 @@
 /* global Event, DOMParser, adminterface */
 
 import { Modal } from 'bootstrap'
-import { serializeObject } from './utils'
+import { serializeObject, deepMergeObject } from './utils'
 import FlatpickerInit from '../initializers/flatpickr'
 import TomSelect from '../initializers/tom_select'
 import Input from './input'
@@ -9,15 +9,19 @@ import PasswordVisibilityTogglerInit from '../initializers/inputs/password_input
 
 class ConfirmDialog {
   constructor (message, inputs, options, callback) {
+    const metaForTranslations = (document.querySelector('#meta-tags-for-js meta[name="translations"]') || {})
+    const metaForCssClasses = (document.querySelector('#meta-tags-for-js meta[name="css_classes"]') || {})
+    const cssClasses = (JSON.parse(metaForCssClasses.content) || {}).confirm_dialog
+    const translations = (JSON.parse(metaForTranslations.content) || {}).confirm_dialog
     const defaults = {
       buttons: {
         ok: {
-          text: 'Confirm',
-          class: 'btn btn-primary'
+          text: translations.ok,
+          class: cssClasses.ok
         },
         cancel: {
-          text: 'Cancel',
-          class: 'btn btn-link'
+          text: translations.cancel,
+          class: cssClasses.cancel
         }
       }
     }
@@ -30,7 +34,7 @@ class ConfirmDialog {
       afterOpen: new Event('confirm_dialog:after_open')
     }
 
-    this.options = { ...defaults, ...options }
+    this.options = deepMergeObject(defaults, options)
     this._bind()
   }
 

--- a/app/javascript/adminterface/lib/inputs/date_picker_input.js
+++ b/app/javascript/adminterface/lib/inputs/date_picker_input.js
@@ -2,11 +2,11 @@ import BaseInput from './base_input'
 
 class DatePickerInput extends BaseInput {
   _defaultInputHTMLOptions () {
-    const meta = (document.querySelector('#meta-tags-for-js meta[name="inputs"]') || {})
-    const content = JSON.parse(meta.content)
+    const metaForComponents = (document.querySelector('#meta-tags-for-js meta[name="components"]') || {})
+    const components = JSON.parse(metaForComponents.content)
     const options = {
       type: 'text',
-      'data-aa-datepicker': this.options.flatpickr || content.date_picker
+      'data-aa-datepicker': this.options.flatpickr || (components.inputs || {}).date_picker
     }
 
     return { ...super._defaultInputHTMLOptions(), ...options }

--- a/app/javascript/adminterface/lib/inputs/datetime_picker_input.js
+++ b/app/javascript/adminterface/lib/inputs/datetime_picker_input.js
@@ -2,11 +2,11 @@ import BaseInput from './base_input'
 
 class DateTimePickerInput extends BaseInput {
   _defaultInputHTMLOptions () {
-    const meta = (document.querySelector('#meta-tags-for-js meta[name="inputs"]') || {})
-    const content = JSON.parse(meta.content)
+    const metaForComponents = (document.querySelector('#meta-tags-for-js meta[name="components"]') || {})
+    const components = JSON.parse(metaForComponents.content)
     const options = {
       type: 'text',
-      'data-aa-datepicker': this.options.flatpickr || content.datetime_picker
+      'data-aa-datepicker': this.options.flatpickr || (components.inputs || {}).datetime_picker
     }
 
     return { ...super._defaultInputHTMLOptions(), ...options }

--- a/app/javascript/adminterface/lib/inputs/select_input.js
+++ b/app/javascript/adminterface/lib/inputs/select_input.js
@@ -14,8 +14,8 @@ class SelectInput extends BaseInput {
   }
 
   _defaultInputHTMLOptions () {
-    const meta = (document.querySelector('#meta-tags-for-js meta[name="inputs"]') || {})
-    const content = JSON.parse(meta.content)
+    const metaForComponents = (document.querySelector('#meta-tags-for-js meta[name="components"]') || {})
+    const components = JSON.parse(metaForComponents.content)
     const options = {
       class: `form-select ${this.options.as}`
     }
@@ -25,7 +25,7 @@ class SelectInput extends BaseInput {
       if (typeof (this.tom_select) === 'object') {
         options['data-aa-tom-select'] = this.tom_select
       } else {
-        options['data-aa-tom-select'] = content.tom_select
+        options['data-aa-tom-select'] = (components.inputs || {}).tom_select
       }
     }
 

--- a/app/javascript/adminterface/lib/utils.js
+++ b/app/javascript/adminterface/lib/utils.js
@@ -108,9 +108,20 @@ function getObjectValue (data, path) {
   return data
 }
 
+function deepMergeObject (target, source) {
+  for (const key of Object.keys(source)) {
+    if (source[key] instanceof Object) Object.assign(source[key], deepMergeObject(target[key], source[key]))
+  }
+
+  Object.assign(target || {}, source)
+  return target
+}
+
 export {
   cookieGet,
   cookieSet,
+  deepMergeObject,
+  getObjectValue,
   hasTurbolinks,
   queryString,
   queryStringToParams,
@@ -118,6 +129,5 @@ export {
   serializeObject,
   toHTMLAttrString,
   toQueryString,
-  turbolinksVisit,
-  getObjectValue
+  turbolinksVisit
 }

--- a/lib/adminterface/extensions/views/pages/base.rb
+++ b/lib/adminterface/extensions/views/pages/base.rb
@@ -15,8 +15,9 @@ module Adminterface
             div id: "meta-tags-for-js" do
               meta name: "countries", content: ::Adminterface::Data::Countries.call(I18n.locale).to_json
               meta name: "time_zones", content: ::Adminterface::Data::TimeZones.call(I18n.locale).to_json
-              meta name: "inputs", content: inputs_components.to_json
               meta name: "translations", content: I18n.t("active_admin").to_json
+              meta name: "components", content: {inputs: inputs_components}.to_json
+              meta name: "css_classes", content: {confirm_dialog: confirm_dialog_css_classes}.to_json
             end
           end
 
@@ -158,6 +159,6 @@ end
 ActiveAdmin::Views::Pages::Base.class_eval do
   include Adminterface::Configs::Finders
   prepend Adminterface::Extensions::Views::Pages::Base
-  has_css_classes_for :html, :flash
+  has_css_classes_for :html, :flash, :confirm_dialog
   has_components_for :flash, :sidebar, :header, :inputs
 end


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->
<!-- Please ensure your commits follows the [Conventional Commit Messages](https://github.com/CMDBrew/adminterface/blob/main/CODE_OF_CONDUCT.md#conventional-commit-messages) format. -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue Number(s): N/A
When adding a custom confirm dialog, it doesn't use the config styles specified in the `css_classes.yml`. In addition, if we add the `buttons` attribute to the configs, the confirm dialog loses the styling for the buttons.

```ruby
link_to(
    "Confirm", "fake/path",
    data: {
      confirm: "My confirm message",
      "aa-confirm-dialog": {
        buttons: {
          ok: {text: "Okay!"}
        }
      }
    }
  )
```

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
- The confirm dialog now uses configs from `css_classes.yml` and I18n files

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- Combined separate components meta tags into one
- Add new meta tag for `css_classes`

