### PR TITLE
fix: wrong dataset `observerUuid` should be `observerId` for _getPristineObservers

### DIFF
--- a/app/javascript/adminterface/config.js
+++ b/app/javascript/adminterface/config.js
@@ -102,19 +102,19 @@ window.adminterface = {
   addObserver: function (target, data, path) {
     if (!this.debug) return
 
-    const uuid = uuidv4()
-    const observer = { observerId: uuid, path: path, data: data }
+    const id = uuidv4()
+    const observer = { id: id, path: path, data: data }
     this._getPristineObservers()
 
-    if (target) target.setAttribute('data-observer-id', uuid)
+    if (target) target.setAttribute('data-observer-id', id)
 
     this._observers = [...this._observers, observer]
-    return uuid
+    return id
   },
   _getPristineObservers: function () {
     const observers = this._observers || []
-    const uuids = this._trackers().map(el => el.dataset.observerUuid)
-    this._observers = observers.filter(item => uuids.includes(item.uuid))
+    const ids = this._trackers().map(el => el.dataset.observerId)
+    this._observers = observers.filter(item => ids.includes(item.id))
     return this._observers
   },
   _addMeta: function (name) {


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->
<!-- Please ensure your commits follows the [Conventional Commit Messages](https://github.com/CMDBrew/adminterface/blob/main/CODE_OF_CONDUCT.md#conventional-commit-messages) format. -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue Number(s): N/A
- `adminterface.observers` not removing removed trackers.

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
- Fix wrong dataset `observerUuid` should be `observerId` for _getPristineObservers

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
N/A
