### PR TITLE
ci: only upload stats to codeclimate on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
   codeclimate:
     needs: [sqlite, mysql, postgres]
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - name: Download partial coverages


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->
<!-- Please ensure your commits follows the [Conventional Commit Messages](https://github.com/CMDBrew/adminterface/blob/main/CODE_OF_CONDUCT.md#conventional-commit-messages) format. -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): CI

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue Number(s): N/A

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
- Only upload stats to Code Climate on push to the `main` branch

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
N/A
