### PR TITLE
fix: missing thor class for invoke when installing action_text

### DIFF
--- a/lib/generators/adminterface/comments/comments_generator.rb
+++ b/lib/generators/adminterface/comments/comments_generator.rb
@@ -12,7 +12,7 @@ module Adminterface
       end
 
       def install_action_text
-        invoke "action_text:install"
+        rails_command "action_text:install"
       end
 
       def create_initializer

--- a/test/generators/comments_generator_test.rb
+++ b/test/generators/comments_generator_test.rb
@@ -7,7 +7,7 @@ class CommentsGeneratorTest < GeneratorTestCase
   teardown :teardown_app
 
   def stub_action_text_installation
-    described_class.any_instance.stubs(:invoke).with("action_text:install").returns(true)
+    described_class.any_instance.stubs(:rails_command).with("action_text:install").returns(true)
   end
 
   test "installs action text" do


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->
<!-- Please ensure your commits follows the [Conventional Commit Messages](https://github.com/CMDBrew/adminterface/blob/main/CODE_OF_CONDUCT.md#conventional-commit-messages) format. -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue Number(s): closes #113 

When running `rails g adminterface:install`, the system throws the following error:
```bash
install_rails_addons '.../ruby-2.7.2/gems/thor-1.1.0/lib/thor/invocation.rb:112:in invoke': Missing Thor class for invoke action_text:install (RuntimeError)
```
## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
- Replace the `invoke` method with `rails_command`

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
N/A
