### PR TITLE
Bump Bootstrap to 5.1.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task :prepare_assets do
   system "rm -rf test/dummy/public/packs"
   system "rm -rf test/dummy/public/packs-test"
   system "yarn install --frozen-lockfile"
-  system "(cd test/dummy && yarn install --frozen-lockfile)"
+  system "cd test/dummy && yarn install --frozen-lockfile"
 end
 
 # Generate dependency licenses

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@popperjs/core": "^2.10.1",
     "@rails/actiontext": "^6.1.4",
     "@rails/ujs": "^6.1.4",
-    "bootstrap": "^5.1.1",
+    "bootstrap": "^5.1.3",
     "bootstrap-icons": "^1.5.0",
     "flatpickr": "^4.6.9",
     "resolve-url-loader": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,10 +1485,10 @@ bootstrap-icons@^1.5.0:
   resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.5.0.tgz#2cb19da148aa9105cb3174de2963564982d3dc55"
   integrity sha512-44feMc7DE1Ccpsas/1wioN8ewFJNquvi5FewA06wLnqct7CwMdGDVy41ieHaacogzDqLfG8nADIvMNp9e4bfbA==
 
-bootstrap@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.1.tgz#9d6eed81e08feaccedf3adaca51fe4b73a2871df"
-  integrity sha512-/jUa4sSuDZWlDLQ1gwQQR8uoYSvLJzDd8m5o6bPKh3asLAMYVZKdRCjb1joUd5WXf0WwCNzd2EjwQQhupou0dA==
+bootstrap@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.1.3.tgz#ba081b0c130f810fa70900acbc1c6d3c28fa8f34"
+  integrity sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->
<!-- Please ensure your commits follows the [Conventional Commit Messages](https://github.com/CMDBrew/adminterface/blob/main/CODE_OF_CONDUCT.md#conventional-commit-messages) format. -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue Number(s): N/A

Ran into the issue with a new Rails webpacker project that uses `bootstrap@5.1.1`. 
```bash
Module build failed (from ./node_modules/postcss-loader/src/index.js):
ParserError: Syntax Error at line: 1, column 25
```
However, I was using `bootstrap@5.1.1` for my previous project, and it was working fine. Both of them had the same setup except for some differences in dependencies.

I haven't been able to figure out which dependency change causes this issue, but I found out the problem lies within the following lines:
https://github.com/twbs/bootstrap/blob/9437973e58ffc3a45fcb28f92144278064c62ca4/scss/mixins/_grid.scss#L10-L12

If I update these lines to the following, it no longer have issues compiling:
```scss
margin-top: calc(-1 * var(--#{$variable-prefix}gutter-y) * 1); // stylelint-disable-line function-disallowed-list
margin-right: calc(-1 * var(--#{$variable-prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
margin-left: calc(-1 * var(--#{$variable-prefix}gutter-x) * .5); // stylelint-disable-line function-disallowed-list
```

After a little bit more research, I found out the `sass` package causes this issue. 

If you use `sass@1.40.x`, you will get the compilation error. However, if you downgrade to `sass@1.39.0`, the error no longer exists.

Possibly related to the `calc` function changes in https://github.com/sass/dart-sass/compare/1.39.0...1.42.1

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
- Bump Bootstrap to v5.1.3. This includes the workaround for dart sass compile error

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
N/A
