### PR TITLE
HTTP tabs render incorrect url

### DIFF
--- a/lib/adminterface/extensions/views/components/tabs.rb
+++ b/lib/adminterface/extensions/views/components/tabs.rb
@@ -6,14 +6,9 @@ module Adminterface
           def build_menu_item(title, options, &_block)
             fragment = options.fetch(:id, fragmentize(title))
             html_options = options.fetch(:html_options, {})
+
             li html_options.merge(class: "nav-item", role: "presentation") do
-              if @http
-                params[:tab] ||= @default_tab || fragment
-                link_to(title, url_for(tab: fragment, anchor: id, anchor_id: id), **toggler_options(fragment))
-              else
-                options = toggler_options(fragment).merge(data: {"bs-toggle": "tab", "bs-target": "##{fragment}"})
-                link_to(title, "##{fragment}", **options)
-              end
+              @http ? link_to_http(title, fragment) : link_to_js(title, fragment)
             end
           end
 
@@ -39,6 +34,24 @@ module Adminterface
           end
 
           private
+
+          def link_to_js(title, fragment)
+            options = toggler_options(fragment).merge(data: {"bs-toggle": "tab", "bs-target": "##{fragment}"})
+            link_to(title, "##{fragment}", **options)
+          end
+
+          def link_to_http(title, fragment)
+            params[:tab] ||= @default_tab || fragment
+
+            link_to(title,
+              url_for(controller: resource_scope[:controller],
+                      action: resource_scope[:action], tab: fragment, anchor: id, anchor_id: id),
+              **toggler_options(fragment))
+          end
+
+          def resource_scope
+            session.fetch(:resource_scope, {}).with_indifferent_access
+          end
 
           def toggler_options(fragment)
             defaults = {id: "#{fragment}-tab", "aria-controls": fragment}

--- a/test/dummy/app/admin/users.rb
+++ b/test/dummy/app/admin/users.rb
@@ -80,31 +80,57 @@ ActiveAdmin.register User do
   end
 
   form do |f|
-    panel do
-      f.inputs do
-        columns do
-          column(span: 6) { f.input :name }
-          column(span: 6) { f.input :email }
-        end
+    if f.object.new_record?
+      panel do
+        f.inputs do
+          columns do
+            column(span: 6) { f.input :name }
+            column(span: 6) { f.input :email }
+          end
 
-        f.input :password, password_visibility: true, input_html: {autocomplete: "new-password"}
-        f.input :biography, input_counter: true
-        f.has_many :user_addresses, allow_destroy: true, sortable: :position, sortable_start: 1 do |k|
-          k.inputs(class: "row") do
-            k.input :fullname, wrapper_html: {class: "col-lg-6"}
-          end +
-            k.inputs(class: "row") do
-              k.input :address_line1, wrapper_html: {class: "col-lg-6"}
-              k.input :address_line2, wrapper_html: {class: "col-lg-6"}
-              k.input :city
-              k.input :state
-              k.input :zip_code
-              k.input :country
-            end
+          f.input :password, password_visibility: true, input_html: {autocomplete: "new-password"}
+          f.input :biography, input_counter: true
         end
       end
-      f.actions
+    else
+      tabs http: true do
+        tab :profile do
+          panel do
+            f.inputs do
+              columns do
+                column(span: 6) { f.input :name }
+                column(span: 6) { f.input :email }
+              end
+
+              f.input :password, password_visibility: true, input_html: {autocomplete: "new-password"}
+              f.input :biography, input_counter: true
+            end
+          end
+        end
+
+        tab :addresses do
+          panel do
+            f.inputs do
+              f.has_many :user_addresses, allow_destroy: true, sortable: :position, sortable_start: 1 do |k|
+                k.inputs(class: "row") do
+                  k.input :fullname, wrapper_html: {class: "col-lg-6"}
+                end +
+                  k.inputs(class: "row") do
+                    k.input :address_line1, wrapper_html: {class: "col-lg-6"}
+                    k.input :address_line2, wrapper_html: {class: "col-lg-6"}
+                    k.input :city
+                    k.input :state
+                    k.input :zip_code
+                    k.input :country
+                  end
+              end
+            end
+          end
+        end
+      end
     end
+
+    f.actions
   end
 
   sidebar "Customer Details", only: :show do

--- a/test/lib/extensions/views/components/tabs_test.rb
+++ b/test/lib/extensions/views/components/tabs_test.rb
@@ -79,6 +79,8 @@ module TabsTest
     class HttpTabsView < ::ActiveAdmin::IntegrationTestHelper::MockActionView
       def url_for(*args)
         options = args.extract_options!
+        options.delete(:controller)
+        options.delete(:action)
         anchor = options[:anchor].present? ? "##{options.delete(:anchor)}" : ""
 
         if options[:tab].present?


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the title above -->
<!-- Please ensure your commits follows the [Conventional Commit Messages](https://github.com/CMDBrew/adminterface/blob/main/CODE_OF_CONDUCT.md#conventional-commit-messages) format. -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behaviour?
<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->
Issue Number(s): N/A
- `base_controller` overrides not executing
- HTTP tabs render incorrect URLs after form submissions with `url_for`

## What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
- use `ActiveAdmin.after_load` to override ActiveAdmin's `base_controller`
- add explicit `controller` and `action` params to `url_for` when rendering HTTP tabs

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
N/A
